### PR TITLE
Correcting information on forms for part-time disabled students

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms/outcome_dsa_1415_pt.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcome_dsa_1415_pt.govspeak.erb
@@ -4,24 +4,12 @@
 
 <% content_for :body do %>
 
-  There are two different forms.  You only need to complete one.
-
-  If you’re only applying for DSA and no other student finance, complete the DSA1 full.
+  To apply for Disabled Students’ Allowance for a part-time, Open University or postgraduate course, complete the full DSA1.
 
   Academic Year | Form
   - | -
   2014 to 2015 | [DSA1 - full form (PDF, 653KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_dsa1_form_1415_d.pdf)
   2014 to 2015 | [DSA1 - guidance notes (PDF, 90KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_dsa1_notes_1415_d.pdf)
-
-
-  If you've already applied for other student finance (like a Tuition Fee Loan) complete the DSA slim and put your Customer Reference Number (CRN) in the form.
-
-
-  Academic Year | Form
-  - | -
-  2014 to 2015 | [DSA1 - slim form (PDF, 490KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_dsa_slim_form_1415_d.pdf)
-  2014 to 2015 | [DSA1 - guidance notes (PDF, 90KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_dsa1_notes_1415_d.pdf)
-
 
   <%= render partial: 'where_to_send_your_forms_uk.govspeak.erb' -%>
 <% end %>

--- a/lib/smart_answer_flows/student-finance-forms/outcome_dsa_1516_pt.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcome_dsa_1516_pt.govspeak.erb
@@ -4,23 +4,13 @@
 
 <% content_for :body do %>
 
-  There are two different forms.  You only need to complete one.
-
-  If you’re only applying for DSA and no other student finance, complete the DSA1 full.
-
+  To apply for Disabled Students’ Allowance for a part-time, Open University or postgraduate course, complete the full DSA1.
+ 
   Academic Year | Form
   - | -
   2015 to 2016 | [DSA1 - full form (PDF, 653KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_form_1516_d.pdf)
   2015 to 2016 | [DSA1 - guidance notes (PDF, 90KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_notes_1516_d.pdf)
 
-
-  If you've already applied for other student finance (like a Tuition Fee Loan) complete the DSA slim and put your Customer Reference Number (CRN) in the form.
-
-
-  Academic Year | Form
-  - | -
-  2015 to 2016 | [DSA1 - slim form (PDF, 490KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa_slim_form_1516_d.pdf)
-  2015 to 2016 | [DSA1 - guidance notes (PDF, 90KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_notes_1516_d.pdf)
 
 
   <%= render partial: 'where_to_send_your_forms_uk.govspeak.erb' -%>


### PR DESCRIPTION
Student finance forms (Piv #102061012/Zen 1119890) - the ‘slim’ form isn’t relevant to disabled
part-time students, is causing confusion, and should be removed from these two answers.
